### PR TITLE
fix: add .js extension to @nestjs/* deep imports

### DIFF
--- a/lib/exceptions/validate.exception.ts
+++ b/lib/exceptions/validate.exception.ts
@@ -1,5 +1,5 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { isString } from '@nestjs/common/utils/shared.utils';
+import { isString } from '@nestjs/common/utils/shared.utils.js';
 import { ValidationError } from '../interfaces/validation-error.interface.js';
 import { ValidationErrorExceptionDetail } from '../types/validation-error-exception-detail.type.js';
 import { ValidationErrorException } from '../types/validation-error-exception.type.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1137,28 +1137,6 @@
                 }
             }
         },
-        "node_modules/@hodfords/nestjs-cls-translation/node_modules/@nestjs/platform-express": {
-            "version": "11.2.3",
-            "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.2.3.tgz",
-            "integrity": "sha512-YFQvRXT2de1qNL9LJPUBQ31+RsfI4cJ+sbpU9ENM/hDCgoHSEhm7oxUuGGKmhTZBNZEYm8mDYdfoTFmAH1LIJg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "cors": "2.8.6",
-                "express": "5.2.1",
-                "multer": "2.2.0",
-                "path-to-regexp": "8.4.2",
-                "tslib": "2.8.1"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/nest"
-            },
-            "peerDependencies": {
-                "@nestjs/common": "^11.0.0",
-                "@nestjs/core": "^11.0.0"
-            }
-        },
         "node_modules/@hodfords/nestjs-cls-translation/node_modules/file-type": {
             "version": "21.3.4",
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hodfords/nestjs-exception",
-    "version": "12.0.0",
+    "version": "12.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-exception",
-            "version": "12.0.0",
+            "version": "12.0.1",
             "license": "ISC",
             "dependencies": {
                 "@grpc/grpc-js": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-exception",
-    "version": "12.0.0",
+    "version": "12.0.1",
     "description": "A NestJS module for handling and customizing exceptions with ease.",
     "type": "module",
     "main": "./index.js",


### PR DESCRIPTION
Adds the missing `.js` extension to deep imports into `@nestjs/*` subpaths.

## Why this is a real bug, not a cosmetic change

These specifiers resolve today only because `@nestjs/*@12` ships an `exports` map containing
`"./*": "./*.js"`, which quietly supplies the extension. The moment npm nests an **older**
`@nestjs/*` — which has no `exports` map at all — Node falls back to plain path resolution, the
extension is no longer supplied, and the import throws at runtime.

That is not hypothetical. Installing `@hodfords/nestjs-cls-translation@12.0.0` into a consumer
produces exactly this:

```
Error: Cannot find module '.../@hodfords/nestjs-cls-translation/node_modules/@nestjs/core/helpers/execution-context-host'
imported from .../@hodfords/nestjs-cls-translation/resolves/request.resolver.js
```

The nesting happens because `nestjs-cls@6.2.2` still declares `@nestjs/core ">= 10 < 12"`, so npm
installs `@nestjs/core@11.2.3` (CJS, no `exports` map) underneath it. An `overrides` entry in this
repo hides the problem locally — but **`overrides` do not propagate to consumers**, so the published
package is broken for anyone who installs it alongside that nesting.

Appending `.js` is strictly more robust: `@nestjs/*@12`'s `exports` map also lists `"./*.js": "./*.js"`,
so the explicit form resolves under both the new and the old layout.

## Verification

`npm install` → `npm run build` → `npm test` → `npm run lint` → ESM import of the built `dist`, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
