### PR TITLE
fix: restore npm run start:dev for the sample app

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -5,12 +5,9 @@
     "compilerOptions": {
         "assets": [
             {
-                "include": "sample/**/*",
-                "outDir": "dist/sample"
-            },
-            {
-                "include": "lib/**/*",
-                "outDir": "dist/lib"
+                "include": "sample/**/*.json",
+                "outDir": "dist",
+                "watchAssets": true
             }
         ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "@hodfords/nestjs-exception",
-    "version": "12.0.1",
+    "version": "12.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-exception",
-            "version": "12.0.1",
+            "version": "12.0.2",
             "license": "ISC",
             "dependencies": {
                 "@grpc/grpc-js": "1.14.3",
                 "es-toolkit": "1.51.0"
             },
             "devDependencies": {
-                "@hodfords/nestjs-cls-translation": "11.1.0",
+                "@hodfords/nestjs-cls-translation": "12.0.0",
                 "@hodfords/nestjs-eslint-config": "11.0.2",
                 "@hodfords/nestjs-prettier-config": "11.0.1",
                 "@nestjs/cli": "12.0.0",
@@ -1050,127 +1050,20 @@
             }
         },
         "node_modules/@hodfords/nestjs-cls-translation": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@hodfords/nestjs-cls-translation/-/nestjs-cls-translation-11.1.0.tgz",
-            "integrity": "sha512-P74wpZcWwQ/9X/5qdVKN3wJG4XTq3LEw3Z4JK1GHzkX75hJPpb2Xt9qWL4rZYzrI/DA3CSojp92hGvxCH01OeA==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/@hodfords/nestjs-cls-translation/-/nestjs-cls-translation-12.0.0.tgz",
+            "integrity": "sha512-Yr8LhmCGhIdrqu10JKjPE531yY9GES/PP6+NRYG4xNLJmYPmBZS22FU//QZ3Tmpy6IttDsbkKLmEEjmvj9Spyw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "nestjs-cls": "6.0.1",
-                "nestjs-i18n": "10.5.1"
+                "nestjs-cls": "6.2.0",
+                "nestjs-i18n": "10.6.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
                 "nestjs-cls": ">=6.0.0"
-            }
-        },
-        "node_modules/@hodfords/nestjs-cls-translation/node_modules/@nestjs/common": {
-            "version": "11.2.3",
-            "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.2.3.tgz",
-            "integrity": "sha512-obdauJXHfthhepbV+LpGe88OeBlR/Kw9lwjLo0Utzc//agoLXYb9DUGhPQWtm81IpBWMv+19eiwcve9MsBZwXA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "file-type": "21.3.4",
-                "iterare": "1.2.1",
-                "load-esm": "1.0.3",
-                "tslib": "2.8.1",
-                "uid": "2.0.2"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/nest"
-            },
-            "peerDependencies": {
-                "class-transformer": ">=0.4.1",
-                "class-validator": ">=0.13.2",
-                "reflect-metadata": "^0.1.12 || ^0.2.0",
-                "rxjs": "^7.1.0"
-            },
-            "peerDependenciesMeta": {
-                "class-transformer": {
-                    "optional": true
-                },
-                "class-validator": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@hodfords/nestjs-cls-translation/node_modules/@nestjs/core": {
-            "version": "11.2.3",
-            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.2.3.tgz",
-            "integrity": "sha512-vkA9/Ja0Z3hvqXErSa+HaxrfF+cNXthNFi8VPNEKVli4rMd009yExAl0gLmko/Kf8peDXr72u1RN+j9Da2ukHg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "fast-safe-stringify": "2.1.1",
-                "iterare": "1.2.1",
-                "path-to-regexp": "8.4.2",
-                "tslib": "2.8.1",
-                "uid": "2.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/nest"
-            },
-            "peerDependencies": {
-                "@nestjs/common": "^11.0.0",
-                "@nestjs/microservices": "^11.0.0",
-                "@nestjs/platform-express": "^11.0.0",
-                "@nestjs/websockets": "^11.0.0",
-                "reflect-metadata": "^0.1.12 || ^0.2.0",
-                "rxjs": "^7.1.0"
-            },
-            "peerDependenciesMeta": {
-                "@nestjs/microservices": {
-                    "optional": true
-                },
-                "@nestjs/platform-express": {
-                    "optional": true
-                },
-                "@nestjs/websockets": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@hodfords/nestjs-cls-translation/node_modules/file-type": {
-            "version": "21.3.4",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
-            "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@tokenizer/inflate": "^0.4.1",
-                "strtok3": "^10.3.4",
-                "token-types": "^6.1.1",
-                "uint8array-extras": "^1.4.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-            }
-        },
-        "node_modules/@hodfords/nestjs-cls-translation/node_modules/nestjs-cls": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/nestjs-cls/-/nestjs-cls-6.0.1.tgz",
-            "integrity": "sha512-FnU8MI5/RKdbNvGmlUMD7nuFs7zUiueNzTjO+sxj7BJbsf7cUmosarppPLXRJ7C1WaZ/gLE9ZAcM6//0q1CQIA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@nestjs/common": ">= 10 < 12",
-                "@nestjs/core": ">= 10 < 12",
-                "reflect-metadata": "*",
-                "rxjs": ">= 7"
             }
         },
         "node_modules/@hodfords/nestjs-eslint-config": {
@@ -6188,10 +6081,26 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/nestjs-cls": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/nestjs-cls/-/nestjs-cls-6.2.0.tgz",
+            "integrity": "sha512-b2Remha7gV5gId3ezjr2tupjqqgYK7/JqjqX6oZ0ZIDFATUggKH1/32+ul2lOe7FepnHasDONDoePuWEE64cug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@nestjs/common": ">= 10 < 12",
+                "@nestjs/core": ">= 10 < 12",
+                "reflect-metadata": "*",
+                "rxjs": ">= 7"
+            }
+        },
         "node_modules/nestjs-i18n": {
-            "version": "10.5.1",
-            "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-10.5.1.tgz",
-            "integrity": "sha512-cJJFz+RUfav23QACpGCq1pdXNLYC3tBesrP14RGoE/YYcD4xosQPX2eyjvDNuo0Ti63Xtn6j57wDNEUKrZqmSw==",
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-10.6.0.tgz",
+            "integrity": "sha512-fPOgwrnb8u8UO6YXNlnamF7GDhNLOHQE8hD/pT/L7oUQibvL7PBZYZgquwppOFRaOPnH0uING2BzQGq7uQNNmQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-exception",
-    "version": "12.0.1",
+    "version": "12.0.2",
     "description": "A NestJS module for handling and customizing exceptions with ease.",
     "type": "module",
     "main": "./index.js",
@@ -19,7 +19,7 @@
     "scripts": {
         "prebuild": "rimraf dist",
         "build": "tsc",
-        "start:dev": "npm run prebuild && nest start --watch",
+        "start:dev": "npm run prebuild && nest start --watch -p tsconfig.sample.json",
         "postbuild": "cp package.json dist/lib && cp README.md dist/lib && cp .npmrc dist/lib",
         "prepare": "is-ci || husky",
         "format": "prettier --write \"lib/**/*.ts\"",
@@ -46,7 +46,7 @@
         "es-toolkit": "1.51.0"
     },
     "devDependencies": {
-        "@hodfords/nestjs-cls-translation": "11.1.0",
+        "@hodfords/nestjs-cls-translation": "12.0.0",
         "@hodfords/nestjs-eslint-config": "11.0.2",
         "@hodfords/nestjs-prettier-config": "11.0.1",
         "@nestjs/cli": "12.0.0",
@@ -68,5 +68,11 @@
         "typescript": "5.9.3",
         "unplugin-swc": "^1.5.7",
         "vitest": "^4.1.10"
+    },
+    "overrides": {
+        "nestjs-cls": {
+            "@nestjs/common": "$@nestjs/common",
+            "@nestjs/core": "$@nestjs/core"
+        }
     }
 }

--- a/tsconfig.sample.json
+++ b/tsconfig.sample.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["lib", "sample"],
+    "exclude": ["node_modules", "dist", "tests", "test", "src", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Problem

`npm run start:dev` reports "Found 0 errors" but the app dies immediately with `Cannot find module .../dist/sample/main.js`. Past that point it hit a DI failure and then i18n errors.

## Cause

- `nest start` compiles with `tsconfig.json`, which excludes the `sample` directory, so the sample is never compiled.
- `nest-cli.json` copied all of `sample/**/*` and `lib/**/*` (including `.ts` files) into `dist`, and the i18n files did not land where the app looks for them (`dist/sample/i18n`).
- `@hodfords/nestjs-cls-translation@11.1.0` pulls in `nestjs-cls@6.0.1`, which depends on `@nestjs/core@11`. The resulting second copy of Nest core in the dependency tree makes DI fail to resolve ModuleRef: `Nest can't resolve dependencies of the TranslationService`.

## Changes

- Add a dedicated `tsconfig.sample.json` for the sample and point `start:dev` at it.
- Narrow the assets to the i18n `.json` files and fix `outDir` so they land at `dist/sample/i18n`.
- Bump `@hodfords/nestjs-cls-translation` `11.1.0` -> `12.0.0` and add the `nestjs-cls` override for `@nestjs/common` / `@nestjs/core`, matching the other packages in the org.
- Bumped version `12.0.1` -> `12.0.2`.

## Verification

- `npm run start:dev`: 0 errors, "Nest application successfully started", no i18n errors
- `npm test`: 1 file / 3 tests pass
- `npm run build`, `npm run lint`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)